### PR TITLE
Hide apps that are disabled

### DIFF
--- a/newtab.js
+++ b/newtab.js
@@ -546,8 +546,13 @@ function getChildrenFunction(node) {
 		case 'apps':
 			return function(callback) {
 				chrome.management.getAll(function(result) {
-					result.push({ id: 'webstore', name: 'Chrome Web Store', appLaunchUrl: 'https://chrome.google.com/webstore' });
-					callback(result);
+					var enabledApps = [];
+					for (var i = 0, len = result.length; i < len; ++i) {
+						if (result[i].enabled)
+							enabledApps.push(result[i]);
+					}
+					enabledApps.push({ id: 'webstore', name: 'Chrome Web Store', appLaunchUrl: 'https://chrome.google.com/webstore' });
+					callback(enabledApps);
 				});
 			};
 		case 'recent':


### PR DESCRIPTION
Currently even apps that are disabled in the Extensions manager are also shown up in the Apps listing. When clicked, they show up as a Chrome error page.

This pull request filters out the disabled apps and only shows the ones enabled.
