### PR TITLE
Sort the apps listing alphabetically

### DIFF
--- a/newtab.js
+++ b/newtab.js
@@ -554,10 +554,10 @@ function getChildrenFunction(node) {
 					enabledApps.sort(function (a, b) {
 						if (a.name < b.name)
 							return -1;
-						else if (a.name == b.name)
-							return 0;
-						else
+						else if (a.name > b.name)
 							return 1;
+						else
+							return 0;
 					});
 					enabledApps.unshift({ id: 'webstore', name: 'Chrome Web Store', appLaunchUrl: 'https://chrome.google.com/webstore' });
 					callback(enabledApps);


### PR DESCRIPTION
This patch sorts the apps listing and also moves the Chrome web store link to the top. Since the list is sorted, it made more sense to have the web store as the first item. Also since it is the first item in the default new tab page's apps listing, we (at least I) tend to look for it first at the top.

Thank you for your time.
