### PR TITLE
Add ability to define number of bookmarks & closed tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var tabs = {};
-var size = 10;
+var size = Number(localStorage.getItem('options.number_closed')) || 10;
 var index = Number(localStorage.getItem('closed.index')) || 0;
 var weather = null;
 var weatherUrl = null;

--- a/newtab.css
+++ b/newtab.css
@@ -290,3 +290,6 @@ input[type="file"]::-webkit-file-upload-button {
 #options_button {
 	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAA6UlEQVQoz2P4z4AfMhCpQFvccKfpS+Mzeim4TODbPiHpnv8bp/dGlbisUP7elPIk+qXrS31+DAVaKVrcQJol9UHa85DXwZYYCpwuWdwzarRdHPUi41n0y+16GApmrgp47fsm6HXii8xnMS9de7QZ0d1gs2Rv5qOU55lPM58lvvB+azpFkxndkc7/e58u+jltxtG053EvvN6az9dixQwogf8sf8O6T6U9jweaYrFSiwNbSDL+TG6+kA5U4vvGYj32oGb6kld3Jf1Z/IvAR7jigvVVRcWNnAebV+KOLM6f1f97/uvji00mGAsAehYJT6WSCbkAAAAASUVORK5CYII=);
 }
+input.small {
+	width: 2em;
+}

--- a/newtab.html
+++ b/newtab.html
@@ -33,11 +33,13 @@
 	<fieldset>
 		<legend>Content</legend>
 		<div id="options_show_bookmarks"></div>
+		<label><span>Nb of bookmarks</span><input class="small" id="options_number_bookmarks" type="text"/></label>
 		<label><span>Most visited</span><input id="options_show_top" type="checkbox"/></label>
 		<label><span>Apps</span><input id="options_show_apps" type="checkbox"/></label>
 		<label><span>Recent bookmarks</span><input id="options_show_recent" type="checkbox"/></label>
 		<label><span>Weather</span><input id="options_show_weather" type="checkbox"/></label>
 		<label><span>Recently closed</span><input id="options_show_closed" type="checkbox"/></label>
+		<label><span>Nb of recently closed</span><input class="small" id="options_number_closed" type="text"/></label>
 	</fieldset>
 	<fieldset>
 		<legend>Weather</legend>

--- a/newtab.js
+++ b/newtab.js
@@ -691,7 +691,7 @@ function getChildrenFunction(node) {
 			};
 		case 'recent':
 			return function(callback) {
-				chrome.bookmarks.getRecent(10, function(result) {
+				chrome.bookmarks.getRecent(getConfig('number_bookmarks'), function(result) {
 					callback(result);
 				});
 			};
@@ -1117,7 +1117,7 @@ function getApps(callback) {
 // get recently closed tabs
 function getClosed(callback) {
 	var closed = [];
-	var size = 10;
+	var size = getConfig('number_closed');
 	var start = (Number(localStorage.getItem('closed.index')) - 1) || 0;
 
 	for (var i = 0; i < size; i++) {
@@ -1321,7 +1321,9 @@ var config = {
 	newtab: 0,
 	auto_close: 0,
 	auto_scale: 1,
-	css: ''
+	css: '',
+	number_closed: 10,
+	number_bookmarks: 10
 };
 
 // color theme values
@@ -1437,7 +1439,7 @@ function setConfig(key, value) {
 		}
 	} else if (key.substring(0, 7) == 'weather') {
 		refreshWeather();
-	} else if (key.substring(0,4) == 'show') {
+	} else if (key.substring(0,4) == 'show' || key.substring(0,6) == 'number') {
 		var id = key.substring(5);
 		if (!value) {
 			if (coords[id])


### PR DESCRIPTION
When I say _number of bookmarks_, it only affect the recent bookmark list only.

Closed tab might still get some problems if the defined value is superior to the previous one and localStorage doesn't have enough items. It's hard to explain, but sometimes, when I reach the previous limit, it reset the localStorage .. So the best things to do, is to _clear recently closed_ manually if you increase the number of closed tab.
It can be something automatic but I find it a bit intrusive for the user..

BTW, this might close #13
