### PR TITLE
Add title tooltip to bookmarked links

### DIFF
--- a/newtab.js
+++ b/newtab.js
@@ -8,7 +8,7 @@ function render(node, target) {
 	var url = node.url || node.appLaunchUrl;
 	if (url) a.href = url;
 	a.innerText = node.title || node.name || '';
-	if (node.tooltip) a.title = node.tooltip;
+	if (node.tooltip) {a.title = node.tooltip} else {a.title = node.title};
 	setClass(a, node);
 
 	a.insertBefore(getIcon(node), a.firstChild);


### PR DESCRIPTION
Hei there, basically I just added a title attribute to the links containing the page title. 
Sometimes either the link names are too long, or due to a narrow screen columns will trim the name of the link. This way it can be difficult to tell (or at least to me! :P) what the page was about, so I just added the tooltip to have a little reminder.

Thanks a lot for this great addon! :)