### PR TITLE
Fix Edit bookmark url

### DIFF
--- a/newtab.js
+++ b/newtab.js
@@ -437,7 +437,7 @@ function getMenuItems(node) {
 		items.push({
 			label: 'Edit bookmarks',
 			action: function() {
-				openLink({ url: 'chrome://bookmarks/#' + node.id }, 1);
+				openLink({ url: 'chrome://bookmarks/?id=' + node.id }, 1);
 			}
 		});
 	return items;


### PR DESCRIPTION
In lastest versions of Chrome the Edit-url for bookmark folder is "chrome://bookmarks/?id=<number>", instead of "chrome://bookmarks/#<number>".